### PR TITLE
call super.init() to correctly register listeners

### DIFF
--- a/src/at/ofai/gate/modularpipelines/ControllerConverter.java
+++ b/src/at/ofai/gate/modularpipelines/ControllerConverter.java
@@ -50,6 +50,9 @@ public class ControllerConverter extends ResourceHelper {
 
   @Override
   public Resource init() throws ResourceInstantiationException {    
+    //this needs to happen so the right listeners get registered
+    super.init();
+    
     try {
       PersistenceManager.registerPersistentEquivalent(
               at.ofai.gate.modularpipelines.ParametrizedCorpusController.class, 


### PR DESCRIPTION
you need to call super.init() otherwise the listener responsible for cleanup doesn't get registered and we end up leaking document handles all over the places!
